### PR TITLE
Added suite_field_formatter option and fixed a couple display issues when suite_names = false

### DIFF
--- a/lib/minitest/display.rb
+++ b/lib/minitest/display.rb
@@ -27,7 +27,7 @@ module MiniTest
         @options ||= {
           :suite_names => true,
           :suite_divider => " | ",
-          :suite_field_formatter => false,
+          :suite_field_formatter => false, # Examples: 1 line output: " | %s", multi-line output: "\n %s"
           :suite_time => true,
           :color => true,
           :wrap_at => 80,


### PR DESCRIPTION
Added suite_field_formatter option to have more control over whitespace without forced newlines except before the suite name. Now you can have 1 line output for each suite name if that is your preferred output.

Sample suite_field_formatter => " | %s" # creates nice 1 line output
Sample suite_field_formatter => "\n %s" # creates nice multiline output

Also fixed an exception where the suite_names was set to false and the wrap_count was trying to be decremented. Fixed display issues when suite_names was set to false.
