### PR TITLE
Escape percent signs

### DIFF
--- a/lib/minitest/display.rb
+++ b/lib/minitest/display.rb
@@ -1,4 +1,4 @@
-require 'minitest' 
+require 'minitest'
 
 class Hash
   unless method_defined?(:deep_merge!)
@@ -113,7 +113,7 @@ module Minitest
       def printable_suite?(suite)
         !DONT_PRINT_CLASSES.include?(suite.to_s)
       end
-      
+
       # Add a recorder which for each test that has a `record`.
       # Optionally can also have an:
       #
@@ -162,7 +162,7 @@ module Minitest
         @suite_finished = Time.now
         time = @suite_finished.to_f - @suite_started.to_f
         print "\n#{' ' * @suite_header.length}#{display.options[:suite_divider]}"
-        print "%.2f s" % time 
+        print "%.2f s" % time
         run_recorder_method(:record_suite_finished, suite, @assertions, time)
       end
 
@@ -174,7 +174,7 @@ module Minitest
 
       def report
         record_suite_finished(@current_suite) if @current_suite
-        puts 
+        puts
         display_slow_tests if display.options[:output_slow]
         display_slow_suites if display.options[:output_slow_suites]
         run_recorder_method(:record_tests_finished, @total_tests, @total_assertions, @total_failures, @total_errors, Time.now.to_f - @tests_started)
@@ -187,7 +187,7 @@ module Minitest
           record_suite_started(suite)
           @assertions = 0
         end
-        @assertions += result.assertions 
+        @assertions += result.assertions
         @total_assertions += result.assertions
         @total_tests += 1
         output = if result.error?
@@ -225,7 +225,7 @@ module Minitest
         times = @test_times.map { |suite, tests| [suite, tests.map(&:last).inject {|sum, n| sum + n }] }.sort { |a, b| b[1] <=> a[1] }
         puts "Slowest suites:"
         times[0..display.options[:output_slow_suites].to_i].each do |suite, time|
-          puts "%.2f s\t#{suite.gsub(/%/, '%%')}" % time
+          puts "%.2f s\t#{suite.name.gsub(/%/, '%%')}" % time
         end
       end
 

--- a/lib/minitest/display.rb
+++ b/lib/minitest/display.rb
@@ -217,7 +217,7 @@ module Minitest
         times = @test_times.values.flatten(1).sort { |a, b| b[1] <=> a[1] }
         puts "Slowest tests:"
         times[0..display.options[:output_slow].to_i].each do |test_name, time|
-          puts "%.2f s\t#{test_name}" % time
+          puts "%.2f s\t#{test_name.gsub(/%/, '%%')}" % time
         end
       end
 
@@ -225,7 +225,7 @@ module Minitest
         times = @test_times.map { |suite, tests| [suite, tests.map(&:last).inject {|sum, n| sum + n }] }.sort { |a, b| b[1] <=> a[1] }
         puts "Slowest suites:"
         times[0..display.options[:output_slow_suites].to_i].each do |suite, time|
-          puts "%.2f s\t#{suite}" % time
+          puts "%.2f s\t#{suite.gsub(/%/, '%%')}" % time
         end
       end
 

--- a/test/test_minitest-display.rb
+++ b/test/test_minitest-display.rb
@@ -1,16 +1,17 @@
 require 'helper'
+require 'minitest/spec'
 
 class TestMinitestDisplay < MiniTest::Test
 
   def test_runs_basic_test_with_default_settings
     capture_test_output <<-TESTCASE
-      class BasicTest < Minitest::Test
+      describe "BasicTest" do
 
-        def test_truth
+        it "asserts truth" do
           assert true
         end
 
-        def test_equality
+        it "asserts equality" do
           assert_equal 'test', 'test'
         end
       end
@@ -22,13 +23,13 @@ class TestMinitestDisplay < MiniTest::Test
 
   def test_runs_basic_test_with_failures
     capture_test_output <<-TESTCASE
-      class BasicTest < Minitest::Test
+      describe "BasicTest" do
 
-        def test_truth
+        it "fails when asserting false" do
           assert false
         end
 
-        def test_equality
+        it "asserts equality" do
           assert_equal 'test', 'test'
         end
       end
@@ -41,24 +42,25 @@ class TestMinitestDisplay < MiniTest::Test
 
   def test_runs_basic_test_with_multiple_suites
     capture_test_output <<-TESTCASE
-      class BasicTest < Minitest::Test
 
-        def test_truth
+      describe "BasicTest" do
+
+        it "fails when asserting false" do
           assert false
         end
 
-        def test_equality
+        it "asserts equality" do
           assert_equal 'test', 'test'
         end
       end
 
-      class AnotherBasicTest < Minitest::Test
+      describe "AnotherBasicTest" do
 
-        def test_truth
+        it "fails when asserting false" do
           assert false
         end
 
-        def test_equality
+        it "asserts equality" do
           assert_equal 'test', 'test'
         end
       end
@@ -78,13 +80,14 @@ class TestMinitestDisplay < MiniTest::Test
           :success => 'PASS'
         }
       }
-      class PrintTest < Minitest::Test
 
-        def test_truth
+      describe "PrintTest" do
+
+        it "fails when asserting false" do
           assert false
         end
 
-        def test_equality
+        it "asserts equality" do
           assert_equal 'test', 'test'
         end
       end
@@ -104,19 +107,46 @@ class TestMinitestDisplay < MiniTest::Test
         },
         :output_slow => true
       }
-      class PrintTest < Minitest::Test
 
-        def test_truth
+      describe "PrintTest" do
+
+        it "fails when asserting false" do
           assert false
         end
 
-        def test_equality
+        it "asserts equality" do
           assert_equal 'test', 'test'
         end
       end
     TESTCASE
 
     assert_output(/PrintTest \/\//)
+    assert_output(/F/)
+    assert_output(/PASS/)
+    assert_output(/Slowest tests:/)
+  end
+
+  def test_runs_basic_test_suite_with_slow_output_and_percent_sign
+    capture_test_output <<-TESTCASE
+      MiniTest::Display.options = {
+        :suite_divider => ' // ',
+        :print => {
+          :success => 'PASS'
+        }
+      }
+      describe "Print%Test" do
+
+        it "fails when asserting false" do
+          assert false
+        end
+
+        it "accepts tests with a % sign in the name" do
+          assert_equal "0%", "0%"
+        end
+      end
+    TESTCASE
+
+    assert_output(/Print%Test \/\//)
     assert_output(/F/)
     assert_output(/PASS/)
     assert_output(/Slowest tests:/)
@@ -142,13 +172,13 @@ class TestMinitestDisplay < MiniTest::Test
 
       MiniTest::Display.add_recorder TestRecorder
 
-      class PrintTest < Minitest::Test
+      describe "PrintTest" do
 
-        def test_truth
+        it "fails when asserting false" do
           assert false
         end
 
-        def test_equality
+        it "asserts equality" do
           assert_equal 'test', 'test'
         end
       end
@@ -157,6 +187,6 @@ class TestMinitestDisplay < MiniTest::Test
     assert_output(/PrintTest \/\//)
     assert_output(/F/)
     assert_output(/PASS/)
-    assert_output(/I just recorded test_truth/)
+    assert_output(/I just recorded.*fails when asserting false/)
   end
 end


### PR DESCRIPTION
When you have a `%` sign in your test name:

```
Slowest tests:
/opt/app/paperless-development/shared/bundle/ruby/2.1.0/gems/minitest-display-0.3.0/lib/minitest/display.rb:220:in `%': too few arguments (ArgumentError)
	from /opt/app/paperless-development/shared/bundle/ruby/2.1.0/gems/minitest-display-0.3.0/lib/minitest/display.rb:220:in `block in display_slow_tests'
	from /opt/app/paperless-development/shared/bundle/ruby/2.1.0/gems/minitest-display-0.3.0/lib/minitest/display.rb:219:in `each'
	from /opt/app/paperless-development/shared/bundle/ruby/2.1.0/gems/minitest-display-0.3.0/lib/minitest/display.rb:219:in `display_slow_tests'
	from /opt/app/paperless-development/shared/bundle/ruby/2.1.0/gems/minitest-display-0.3.0/lib/minitest/display.rb:178:in `report'
	from /opt/src/paperlesspost/paperless-post/vendor/bundle/ruby/2.1.0/gems/minitest-5.5.1/lib/minitest.rb:633:in `each'
	from /opt/src/paperlesspost/paperless-post/vendor/bundle/ruby/2.1.0/gems/minitest-5.5.1/lib/minitest.rb:633:in `report'
	from /opt/src/paperlesspost/paperless-post/vendor/bundle/ruby/2.1.0/gems/minitest-5.5.1/lib/minitest.rb:129:in `run'
	from /opt/src/paperlesspost/paperless-post/vendor/bundle/ruby/2.1.0/gems/minitest-5.5.1/lib/minitest.rb:56:in `block in autorun'
	from /opt/src/paperlesspost/paperless-post/vendor/bundle/ruby/2.1.0/gems/spin-0.7.1/lib/spin.rb:333:in `fork'
	from /opt/src/paperlesspost/paperless-post/vendor/bundle/ruby/2.1.0/gems/spin-0.7.1/lib/spin.rb:333:in `fork_and_run'
	from /opt/src/paperlesspost/paperless-post/vendor/bundle/ruby/2.1.0/gems/spin-0.7.1/lib/spin.rb:207:in `run_pushed_tests'
	from /opt/src/paperlesspost/paperless-post/vendor/bundle/ruby/2.1.0/gems/spin-0.7.1/lib/spin.rb:62:in `block (2 levels) in serve'
	from /opt/src/paperlesspost/paperless-post/vendor/bundle/ruby/2.1.0/gems/spin-0.7.1/lib/spin.rb:47:in `loop'
	from /opt/src/paperlesspost/paperless-post/vendor/bundle/ruby/2.1.0/gems/spin-0.7.1/lib/spin.rb:47:in `block in serve'
	from /opt/src/paperlesspost/paperless-post/vendor/bundle/ruby/2.1.0/gems/spin-0.7.1/lib/spin.rb:294:in `open_socket'
	from /opt/src/paperlesspost/paperless-post/vendor/bundle/ruby/2.1.0/gems/spin-0.7.1/lib/spin.rb:36:in `serve'
	from /opt/src/paperlesspost/paperless-post/vendor/bundle/ruby/2.1.0/gems/spin-0.7.1/lib/spin/cli.rb:43:in `run'
	from /opt/src/paperlesspost/paperless-post/vendor/bundle/ruby/2.1.0/gems/spin-0.7.1/bin/spin:3:in `<top (required)>'
	from /opt/src/paperlesspost/paperless-post/vendor/bundle/ruby/2.1.0/bin/spin:23:in `load'
	from /opt/src/paperlesspost/paperless-post/vendor/bundle/ruby/2.1.0/bin/spin:23:in `<main>'
```

This is because `%` isn't being escaped and its being passed to `sprintf`. 