### PR TITLE
Changed return value of Minitest::Display.recorders to suppress warni…

### DIFF
--- a/lib/minitest/display.rb
+++ b/lib/minitest/display.rb
@@ -133,7 +133,7 @@ module Minitest
 
       # An array of all the registered MiniTest::Display recorders
       def recorders
-        @recorders || []
+        (defined? @recorders) ? @recorders : []
       end
     end
 

--- a/lib/minitest/display.rb
+++ b/lib/minitest/display.rb
@@ -23,6 +23,13 @@ module Minitest
     VERSION = '0.3.1'
 
     class << self
+      def initialize
+        @recorders = []
+      end
+
+      # An array of all the registered MiniTest::Display recorders
+      attr_reader @recorders
+
       def options
         @options ||= {
           :suite_names => true,
@@ -127,14 +134,9 @@ module Minitest
       #
       def add_recorder(new_recorder)
         new_recorder_instance = new_recorder.new(self)
-        @recorders ||= []
         @recorders << new_recorder_instance
       end
 
-      # An array of all the registered MiniTest::Display recorders
-      def recorders
-        (defined? @recorders) ? @recorders : []
-      end
     end
 
     class Reporter < ::Minitest::Reporter


### PR DESCRIPTION
Hi @quirkey, thanks for the great gem.  I was getting a lot of warnings related to `@recorders` being uninitialized in the `recorders` function.  I have changed the return value to do an additional check using the `defined?` method.  Please have a look and incorporate if you like.
